### PR TITLE
Support V7 share links

### DIFF
--- a/src/components/Attach.css
+++ b/src/components/Attach.css
@@ -22,11 +22,11 @@
 .Attach.Attach--invalid .Attach__Error {
   box-sizing: border-box;
   display: block;
-  padding: .5em;
+  padding: 0.5em;
   color: #ef7564;
   font-size: 9pt;
   margin: 0;
-  padding: .5em 0;
+  padding: 0.5em 0;
 }
 .Attach.Attach--invalid .Attach__Error a {
   color: #ef7564;

--- a/src/components/Section.js
+++ b/src/components/Section.js
@@ -48,7 +48,7 @@ export default class Section extends React.Component {
   render () {
     return (
       <div className='u-clearfix'>
-        {this.state.attachments.map(attachment =>
+        {this.state.attachments.map(attachment => (
           <SectionItem
             {...this.props}
             attachment={attachment}
@@ -57,7 +57,7 @@ export default class Section extends React.Component {
             key={attachment.id}
             updateCover={this.fetch}
           />
-        )}
+        ))}
       </div>
     )
   }

--- a/src/components/__snapshots__/Preview.test.js.snap
+++ b/src/components/__snapshots__/Preview.test.js.snap
@@ -177,10 +177,10 @@ exports[`Preview Preview with cover should be able disconnect prototype and cove
           Modified:
           <span
             className="date"
-            title="6 months ago"
+            title="8 months ago"
           >
              
-            6 months ago
+            8 months ago
           </span>
            
           by 
@@ -369,10 +369,10 @@ exports[`Preview Preview with cover should be able to remove cover 1`] = `
           Modified:
           <span
             className="date"
-            title="6 months ago"
+            title="8 months ago"
           >
              
-            6 months ago
+            8 months ago
           </span>
            
           by 
@@ -561,10 +561,10 @@ exports[`Preview Preview with cover should be able to track navigation clicks 1`
           Modified:
           <span
             className="date"
-            title="6 months ago"
+            title="8 months ago"
           >
              
-            6 months ago
+            8 months ago
           </span>
            
           by 
@@ -747,10 +747,10 @@ exports[`Preview Preview without cover should be able disconnect prototype and c
           Modified:
           <span
             className="date"
-            title="6 months ago"
+            title="8 months ago"
           >
              
-            6 months ago
+            8 months ago
           </span>
            
           by 
@@ -933,10 +933,10 @@ exports[`Preview Preview without cover should be able to set cover 1`] = `
           Modified:
           <span
             className="date"
-            title="6 months ago"
+            title="8 months ago"
           >
              
-            6 months ago
+            8 months ago
           </span>
            
           by 

--- a/src/util/url.js
+++ b/src/util/url.js
@@ -1,8 +1,12 @@
 export const isInVisionUrl = url =>
-  (/^https:\/\/(([a-z0-9-]+(\.[a-z0-9-]+)*?\.)?(invisionapp\.com|invision\.works)\/share|invis.io)\/[A-Z0-9]/g.test(
+  /^https?:\/\/(([a-z0-9-]+(\.[a-z0-9-]+)*?\.)?((invisionapp|invisionbeta)\.com|invision\.works)\/share|invis.io)\/[A-Z0-9]/g.test(
     url
   ) ||
-  /^https:\/\/(([a-z0-9-]+(\.[a-z0-9-]+)*?\.)?(invisionapp\.com|invision\.works)\/prototype)\/[A-Za-z-0-9]*(\/(preview|play|comment|inspect))?/g.test(
-    url))
+  /^https?:\/\/(([a-z0-9-]+(\.[a-z0-9-]+)*?\.)?((invisionapp|invisionbeta)\.com|invision\.works)\/prototype)\/[A-Za-z-0-9]*(\/(preview|play|comment|inspect))?/g.test(
+    url
+  ) ||
+  /^https?:\/\/(([a-z0-9-]+(\.[a-z0-9-]+)*?\.)?((invisionapp|invisionbeta)\.com|invision\.works)\/public\/share)\/[A-Z0-9]*(#\/screens\/[A-Z0-9]*)?/g.test(
+    url
+  )
 
 export default { isInVisionUrl }

--- a/src/util/url.test.js
+++ b/src/util/url.test.js
@@ -1,47 +1,27 @@
 import { isInVisionUrl } from './url.js'
 
-test('https://invis.io/NQ8979O8R', () => {
-  expect(isInVisionUrl('https://invis.io/NQ8979O8R')).toBe(true)
+const validUrls = [
+  'https://in-v6.preview.invisionapp.com/prototype/Slack-Integration-v7-cje6539090003on0op02qgh50',
+  'https://in-v7.invisionapp.com/prototype/firetruck-cjeadm21700093y0pxpbyzlsf',
+  'https://design.invisionapp.com/prototype/Slack-Integration-v7-cjekd47ui00026a0q0ofvab6c/',
+  'https://ent.invisionbeta.com/share/5JD97E4',
+  'https://invis.io/NQ8979O8R',
+  'https://projects.invisionapp.com/share/2B7ZYDVZ3',
+  'https://in.invisionapp.com/share/X28MGQD4Y',
+  'https://projects.staging.invision.works/share/2B7ZYDVZ3',
+  'https://projects.testing10.testing.invision.works/share/GW5ZE',
+  'http://projects.local.invisionapp.com/share/TK3YM',
+  'http://projects.local.invisionapp.com/share/TK3YM/538_Intro',
+  'https://amazing.invisionbeta.com/public/share/87WTI4SMT',
+  'https://amazing.invisionbeta.com/public/share/87WTI4SMT#screens/12345'
+]
+
+validUrls.forEach(url => {
+  test(`${url} should be valid`, () => {
+    expect(isInVisionUrl(url)).toBe(true)
+  })
 })
 
-test('https://projects.invisionapp.com/share/2B7ZYDVZ3', () => {
-  expect(
-    isInVisionUrl('https://projects.invisionapp.com/share/2B7ZYDVZ3')
-  ).toBe(true)
-})
-
-test('https://in.invisionapp.com/share/X28MGQD4Y', () => {
-  expect(isInVisionUrl('https://in.invisionapp.com/share/X28MGQD4Y')).toBe(true)
-})
-
-test('https://projects.staging.invision.works/share/2B7ZYDVZ3', () => {
-  expect(
-    isInVisionUrl('https://projects.staging.invision.works/share/2B7ZYDVZ3')
-  ).toBe(true)
-})
-
-test('https://projects.testing10.testing.invision.works/share/GW5ZE', () => {
-  expect(
-    isInVisionUrl(
-      'https://projects.testing10.testing.invision.works/share/GW5ZE'
-    )
-  ).toBe(true)
-})
-
-test('http://projects.local.invisionapp.com/share/TK3YM', () => {
-  expect(
-    isInVisionUrl('https://projects.local.invisionapp.com/share/TK3YM')
-  ).toBe(true)
-})
-
-test('http://projects.local.invisionapp.com/share/TK3YM/538_Intro', () => {
-  expect(
-    isInVisionUrl(
-      'https://projects.local.invisionapp.com/share/TK3YM/538_Intro'
-    )
-  ).toBe(true)
-})
-
-test('https://google.com', () => {
+test('invalid url', () => {
   expect(isInVisionUrl('https://google.com')).toBe(false)
 })


### PR DESCRIPTION
Added support for unfurling V7 share links. Also addressed some minor formatting issues and updated a snapshot test.

I changed the V6 and V7 share link regexes to allow HTTP. Currently, these links get upgraded to HTTPS, so they should be considered valid. The same is true for UDF links.